### PR TITLE
vcsim: RetrievePropertiesEx & ContinueRetrievePropertiesEx

### DIFF
--- a/property/collector.go
+++ b/property/collector.go
@@ -143,11 +143,23 @@ func (p *Collector) CancelWaitForUpdates(ctx context.Context) error {
 }
 
 // RetrieveProperties wraps RetrievePropertiesEx and ContinueRetrievePropertiesEx to collect properties in batches.
-func (p *Collector) RetrieveProperties(ctx context.Context, req types.RetrieveProperties) (*types.RetrievePropertiesResponse, error) {
+func (p *Collector) RetrieveProperties(
+	ctx context.Context,
+	req types.RetrieveProperties,
+	maxObjectsArgs ...int32) (*types.RetrievePropertiesResponse, error) {
+
+	var opts types.RetrieveOptions
+	if l := len(maxObjectsArgs); l > 1 {
+		return nil, fmt.Errorf("maxObjectsArgs accepts a single value")
+	} else if l == 1 {
+		opts.MaxObjects = maxObjectsArgs[0]
+	}
+
 	req.This = p.Reference()
 	rx, err := methods.RetrievePropertiesEx(ctx, p.roundTripper, &types.RetrievePropertiesEx{
 		This:    req.This,
 		SpecSet: req.SpecSet,
+		Options: opts,
 	})
 	if err != nil {
 		return nil, err

--- a/property/example_test.go
+++ b/property/example_test.go
@@ -187,7 +187,10 @@ func ExampleCollector_WaitForUpdatesEx_addingRemovingPropertyFilters() {
 		}
 
 		// Now create a property filter that will catch the update.
-		pf, err := pc.CreateFilter(ctx, getDatacenterToVMFolderFilter(datacenter))
+		pf, err := pc.CreateFilter(
+			ctx,
+			types.CreateFilter{Spec: getDatacenterToVMFolderFilter(datacenter)},
+		)
 		if err != nil {
 			return fmt.Errorf("failed to create dc2vm property filter: %w", err)
 		}


### PR DESCRIPTION
This patch adds support to vC Sim for `RetrievePropertiesEx` and `ContinueRetrievePropertiesEx` and their paged results semantics.

There is now coverage for the wrapped `RetrievePropertiesEx` call inside of the collector's `RetrieveProperties` method: 
![image](https://github.com/dougm/govmomi/assets/101085/4f38cb19-9812-4cfd-906a-7d45550b202b)

The use of paging may be validated by setting a conditional break point such that it breaks only when there are two attempts to continue paging:

![image](https://github.com/dougm/govmomi/assets/101085/ff419e3c-1676-4c42-8376-d9cbbcd4a258)
![image](https://github.com/dougm/govmomi/assets/101085/f78000a9-c5f0-476e-817d-9d5c3c4b46ed)

The reason it hits on two attempts is because the first call to `RetrievePropertiesEx` returns a single object, and since there are three objects to return, it takes two more calls to `ContinueRetrievePropertiesEx` to obtain that data.